### PR TITLE
백준 10986 / 1806 / 20444

### DIFF
--- a/amm0124/boj/boj_1806.py
+++ b/amm0124/boj/boj_1806.py
@@ -1,0 +1,26 @@
+# boj 1806번 부분합
+# 문제 링크 : https://www.acmicpc.net/problem/1806
+# 투포인터 문제 : start, end index 사용
+# S가 될 때 까지 계속 합을 구함
+# S가 넘어가면 start index를 넘길 때 까지 하나씩 올림. 
+# 이러한 방식을 계속 사용 -> 2N의 시간에 해결 가능
+# 시간 복잡도 O(n)
+
+N, S = map(int, input().split())
+arr = list(map(int, input().split()))
+
+start, end = 0, 0
+sum_ = arr[0]
+ans = 100001
+
+while True:
+    if sum_ < S:
+        end += 1
+        if end == N: break
+        sum_ += arr[end]
+    else: #sum_ >= S
+        sum_ -= arr[start]
+        ans = min(ans, end - start + 1)
+        start += 1
+        
+print(ans if ans != 100001 else 0)

--- a/amm0124/boj/boj_20444.py
+++ b/amm0124/boj/boj_20444.py
@@ -1,0 +1,30 @@
+# 백준 20444 문제 링크 : https://www.acmicpc.net/problem/20444
+# 가로로 a번, 세로로 b번 잘랐을 때 자른 횟수를 n1이라고 하면 : a + b = n1
+# 색종이의 수 (a+1)(b+1) = ab+a+b+1 = ab+n1+1 개 
+# 즉 색종이의 수는 가로로 a와 b에만 영향을 받음
+# k = (a+1)(b+1) = ab+a+b+1 = ab+n+1
+
+# 가로로 a번 , 세로로 b번 자르면 총 사각형 수는 (a+1)(b+1) = k임.
+# x^2 -nx + (k-n-1) = 0 이차방정식의 판별식 d가 근을 양수인 실근을 가져야 함
+
+
+import sys
+n,k=map(int,sys.stdin.readline().split())
+
+d=(n+2)**2-4*k # 판별식 
+if d<0 :
+    print("NO")
+else : #d>=0 
+    if int(d**0.5)**2!=d :
+        print("NO")
+    else : #정수형
+        t=int(d**0.5)
+        if k-n>=1 : 
+            if n%2==0 and t%2==0 :
+                print("YES")
+            elif n%2!=0 and t%2!=0 :
+                print("YES")
+            else :
+                print("NO")
+        else :
+            print("NO")

--- a/amm0124/boj_10986.py
+++ b/amm0124/boj_10986.py
@@ -1,0 +1,18 @@
+import sys 
+
+n,m = map(int,sys.stdin.readline().split())
+seq = list(map(int,sys.stdin.readline().split()))
+#dp=[[-1 for _ in range(n)] for _ in range(n)]
+ 
+dp=[0 for _ in range(m)] # 나머지의 수
+
+p=0
+for i in range(n):
+    p+=seq[i]
+    dp[p%m]+=1
+
+ans=dp[0]
+for i in range(m) :
+    ans += dp[i] * (dp[i]-1) // 2
+
+print(ans)


### PR DESCRIPTION
## TO-DO

- 어떤 플랫폼의 문제를 풀었나요? 백준 
- 어떤 문제를 푸셨나요?  10986 1806 20444


## 문제 유형

10986번
- 어떤 문제 유형인가요? 부분합
나머지 정리를 사용
dp[i] = k : 어떤 구간에서의 부분합을 m으로 나눴을 때 나머지가 i인 부분합의 수 : k라고 하면
kC2를 통해 부분합 나머지 0임을 확인할 수 있음

1086번

투포인터 문제 : start, end index 사용
S가 될 때 까지 계속 합을 구함
 S가 넘어가면 start index를 넘길 때 까지 하나씩 올림. 
이러한 방식을 계속 사용 -> 2N의 시간에 해결 가능. 시간 복잡도 O(n)

20444번 
가로로 a번, 세로로 b번 잘랐을 때 자른 횟수를 n1이라고 하면 : a + b = n1
색종이의 수 (a+1)(b+1) = ab+a+b+1 = ab+n1+1 개 
즉 색종이의 수는 가로로 a와 b에만 영향을 받음
k = (a+1)(b+1) = ab+a+b+1 = ab+n+1

가로로 a번 , 세로로 b번 자르면 총 사각형 수는 (a+1)(b+1) = k임.
 x^2 -nx + (k-n-1) = 0 이차방정식의 판별식 d가 근을 양수인 실근을 가져야 함
이를 통해서 해결

## 리뷰어

xx



